### PR TITLE
Update WebSocket4Net dependency

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="SuperSocket.ClientEngine, Version=0.10.0.0, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
+      <HintPath>..\packages\SuperSocket.ClientEngine.Core.0.10.0\lib\net40-client\SuperSocket.ClientEngine.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
@@ -41,9 +44,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebSocket4Net.0.14.1\lib\net40\WebSocket4Net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebSocket4Net, Version=0.15.2.11, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocket4Net.0.15.2\lib\net40\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ExampleApplication/packages.config
+++ b/ExampleApplication/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WebSocket4Net" version="0.14.1" targetFramework="net40" />
+  <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net40" />
+  <package id="WebSocket4Net" version="0.15.2" targetFramework="net40" />
 </packages>

--- a/PusherClient/PusherClient.csproj
+++ b/PusherClient/PusherClient.csproj
@@ -37,13 +37,15 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="SuperSocket.ClientEngine, Version=0.10.0.0, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
+      <HintPath>..\packages\SuperSocket.ClientEngine.Core.0.10.0\lib\net40-client\SuperSocket.ClientEngine.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data" />
-    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebSocket4Net.0.14.1\lib\net40\WebSocket4Net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebSocket4Net, Version=0.15.2.11, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocket4Net.0.15.2\lib\net40\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/PusherClient/packages.config
+++ b/PusherClient/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
-  <package id="WebSocket4Net" version="0.14.1" targetFramework="net40" />
+  <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net40" />
+  <package id="WebSocket4Net" version="0.15.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This PR is to update WebSocket4Net from 0.14.1 to 0.15.2, which is the latest version.  I've been running this fork for about a week now and haven't had any issues. Below is the changelog between these two versions.

0.15.2
* Upgraded SuperSocket.ClientEngine to support NTLM;

0.15.1
* fixing the bug with queued packets not being sent over TLS/SSL; 
* added a new security option AllowCertificateChainErrors; 
* fixed one unhandled exception which may be thrown when the connection drops;

0.15.0
* fixed the wrong upgrade format in response; 
* added null check for websocket instance in SendCloseHandshake; 
* moved the header item "Host" to the first position to comply rfc7230; 
* fixed a fragmenting issue when do handshake; 
* fixed the user-agent typo in the head; 
* fixed the exception which may be thrown when try to send close handshake; 
* when validating the verbLine, do not require that the optional description parameter be present; 
* fixed the signing issue; 
* removed the support for the target framework WP and Xamarin.
