### PR TITLE
Changed: Added the option to change the host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build
 *.testsettings
 *.vsmdi
 msbuild.log
+/.vs

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -62,6 +62,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.NameResolution, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.NameResolution.4.3.0\lib\net46\System.Net.NameResolution.dll</HintPath>
       <Private>True</Private>

--- a/PusherClient/EventEmitter.cs
+++ b/PusherClient/EventEmitter.cs
@@ -72,6 +72,11 @@ namespace PusherClient
 
         internal void EmitEvent(string eventName, string data)
         {
+            //No data, no event!
+            if(data == null)
+            {
+                return;
+            }
             var obj = JsonConvert.DeserializeObject<dynamic>(data);
 
             // Emit to general listeners regardless of event type

--- a/PusherClient/HttpAuthorizer.cs
+++ b/PusherClient/HttpAuthorizer.cs
@@ -7,17 +7,21 @@ namespace PusherClient
     /// <summary>
     /// An implementation of the <see cref="IAuthorizer"/> using Http
     /// </summary>
-    public class HttpAuthorizer: IAuthorizer
+    public class HttpAuthorizer : IAuthorizer
     {
         private readonly Uri _authEndpoint;
+
+        protected HttpClient _httpClient;
 
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="authEndpoint">The End point to contact</param>
-        public HttpAuthorizer(string authEndpoint)
+        /// <param name="httpClient">An optional HttpClient to use, in case certain properties should be set (e.g. Bearer token)</param>
+        public HttpAuthorizer(string authEndpoint, HttpClient httpClient = null)
         {
             _authEndpoint = new Uri(authEndpoint);
+            _httpClient = httpClient;
         }
 
         /// <summary>
@@ -30,7 +34,7 @@ namespace PusherClient
         {
             string authToken = null;
 
-            using (var httpClient = new HttpClient())
+            using (_httpClient ?? new HttpClient())
             {
                 var data = new List<KeyValuePair<string, string>>
                 {
@@ -39,11 +43,11 @@ namespace PusherClient
                 };
 
                 HttpContent content = new FormUrlEncodedContent(data);
-
-                var response = httpClient.PostAsync(_authEndpoint, content).Result;
-                authToken = response.Content.ToString();
+                
+                var response = _httpClient.PostAsync(_authEndpoint, content).Result;
+                authToken = response.Content.ReadAsStringAsync().Result;
             }
-
+            
             return authToken;
         }
     }

--- a/PusherClient/PusherOptions.cs
+++ b/PusherClient/PusherOptions.cs
@@ -20,6 +20,14 @@
         /// </summary>
         public string Cluster { get; set; } = "mt1";
 
-        internal string Host => $"ws-{Cluster}.pusher.com";
+        /// <summary>
+        /// The Host to use for custom servers to be configurable.
+        /// Defaults to ws-{Cluster}.pusher.com
+        /// </summary>
+        protected string _Host = null;
+        public string Host {
+            get { return _Host ?? $"ws-{Cluster}.pusher.com"; }
+            set { _Host = value; }
+        }
     }
 }


### PR DESCRIPTION
Hi there

Regarding #58 and #49 I added the option to allow custom `Hosts` to be passed and used by the library so that custom server URLs may be used.

In addition I added the option to pass a custom configured `HttpClient` to the `HttpAuthorizer` to setup additional properties, e.g. a Bearer token, without the need to setup additional properties throughout the whole system.

Changelog:
* Changed: Added the option to change the host
* Changed: Added the option to pass a custom HttpClient in case additional properties are required
* Added: Check for non-data messages

I hope the changes are Ok. Otherwise, let me know ^^


Cheers