### PR TITLE
Add proxy support

### DIFF
--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using SuperSocket.ClientEngine;
 //using Nito.AsyncEx;
 using WebSocket4Net;
 
@@ -16,6 +17,7 @@ namespace PusherClient
         private readonly string _url;
         private readonly IPusher _pusher;
         private bool _allowReconnect = true;
+        private Func<IProxyConnector> _proxyFactory;
         
         private int _backOffMillis;
 
@@ -31,10 +33,11 @@ namespace PusherClient
         private TaskCompletionSource<ConnectionState> _connectionTaskComplete = null;
         private TaskCompletionSource<ConnectionState> _disconnectionTaskComplete = null;
 
-        public Connection(IPusher pusher, string url)
+        public Connection(IPusher pusher, string url, Func<IProxyConnector> proxyFactory = null)
         {
             _pusher = pusher;
             _url = url;
+            _proxyFactory = proxyFactory;
         }
 
         internal Task<ConnectionState> Connect()
@@ -57,7 +60,8 @@ namespace PusherClient
             _websocket = new WebSocket(_url)
             {
                 EnableAutoSendPing = true,
-                AutoSendPingInterval = 1
+                AutoSendPingInterval = 1,
+                Proxy = _proxyFactory?.Invoke(),
             };
 
             _websocket.Opened += websocket_Opened;

--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -17,7 +17,7 @@ namespace PusherClient
         private readonly string _url;
         private readonly IPusher _pusher;
         private bool _allowReconnect = true;
-        private Func<IProxyConnector> _proxyFactory;
+        private Func<string, IProxyConnector> _proxyFactory;
         
         private int _backOffMillis;
 
@@ -33,7 +33,7 @@ namespace PusherClient
         private TaskCompletionSource<ConnectionState> _connectionTaskComplete = null;
         private TaskCompletionSource<ConnectionState> _disconnectionTaskComplete = null;
 
-        public Connection(IPusher pusher, string url, Func<IProxyConnector> proxyFactory = null)
+        public Connection(IPusher pusher, string url, Func<string, IProxyConnector> proxyFactory = null)
         {
             _pusher = pusher;
             _url = url;
@@ -61,7 +61,7 @@ namespace PusherClient
             {
                 EnableAutoSendPing = true,
                 AutoSendPingInterval = 1,
-                Proxy = _proxyFactory?.Invoke(),
+                Proxy = _proxyFactory?.Invoke(_url),
             };
 
             _websocket.Opened += websocket_Opened;

--- a/PusherClient/Pusher.cs
+++ b/PusherClient/Pusher.cs
@@ -196,7 +196,7 @@ namespace PusherClient
 
                 var url = ConstructUrl();
 
-                _connection = new Connection(this, url);
+                _connection = new Connection(this, url, Options.ProxyFactory);
                 connectionResult = await _connection.Connect();
             }
             finally

--- a/PusherClient/PusherOptions.cs
+++ b/PusherClient/PusherOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace PusherClient
+﻿using SuperSocket.ClientEngine;
+using System;
+
+namespace PusherClient
 {
     /// <summary>
     /// The Options to set up the connection with <see cref="Pusher"/>
@@ -19,6 +22,12 @@
         /// Gets or sets the Cluster to user for the Host
         /// </summary>
         public string Cluster { get; set; } = "mt1";
+
+        /// <summary>
+        /// Gets or set a IProxyConnector implementation instance may be one of
+        /// HttpConnectProxy, Socks4Connector, or Socks5Connector.
+        /// </summary>
+        public Func<IProxyConnector> ProxyFactory { get; set; }
 
         internal string Host => $"ws-{Cluster}.pusher.com";
     }

--- a/PusherClient/PusherOptions.cs
+++ b/PusherClient/PusherOptions.cs
@@ -27,7 +27,18 @@ namespace PusherClient
         /// Gets or set a IProxyConnector implementation instance may be one of
         /// HttpConnectProxy, Socks4Connector, or Socks5Connector.
         /// </summary>
-        public Func<IProxyConnector> ProxyFactory { get; set; }
+        /// <remarks>
+        /// Interpret first parameter as URL:
+        /// 
+        /// - `ProxyFactory("ws://ws-mt1.pusher.com/xxx")`
+        /// - `ProxyFactory("wss://ws-mt1.pusher.com/xxx")`
+        /// 
+        /// From CHANNELS PROTOCOL section:
+        /// 
+        /// - Default WebSocket ports: 80 (ws) or 443 (wss)
+        /// - For Silverlight clients ports 4502 (ws) and 4503 (wss) may be used.
+        /// </remarks>
+        public Func<string, IProxyConnector> ProxyFactory { get; set; }
 
         internal string Host => $"ws-{Cluster}.pusher.com";
     }


### PR DESCRIPTION
This PR will add `PusherOptions.ProxyFactory` property so that we can specify proxy server manually. 

I'm pending some PRs on [SuperSocket.ClientEngine](https://github.com/kerryjiang/SuperSocket.ClientEngine) project which provides HttpConnectProxy I want to use.
- https://github.com/kerryjiang/SuperSocket.ClientEngine/pull/100 Merged ✔
- https://github.com/kerryjiang/SuperSocket.ClientEngine/pull/102 Merged ✔
- https://github.com/kerryjiang/SuperSocket.ClientEngine/pull/105

Fix #11 