### PR TITLE
Adding alternative methods to avoid dynamic usage

### DIFF
--- a/PusherClient.Tests.Utilities/FakeAuthoriser.cs
+++ b/PusherClient.Tests.Utilities/FakeAuthoriser.cs
@@ -21,7 +21,7 @@ namespace PusherClient.Tests.Utilities
             {
                 var channelData = new PresenceChannelData();
                 channelData.user_id = socketId;
-                channelData.user_info = new { name = _userName };
+                channelData.user_info = new FakeUserInfo { name = _userName };
 
                 authData = provider.Authenticate(channelName, socketId, channelData).ToJson();
             }

--- a/PusherClient.Tests.Utilities/FakeUserInfo.cs
+++ b/PusherClient.Tests.Utilities/FakeUserInfo.cs
@@ -1,0 +1,9 @@
+﻿using PusherServer;
+
+namespace PusherClient.Tests.Utilities
+{
+    public class FakeUserInfo
+    {
+        public string name { get; set; }
+    }
+}

--- a/PusherClient.Tests.Utilities/PusherClient.Tests.Utilities.csproj
+++ b/PusherClient.Tests.Utilities/PusherClient.Tests.Utilities.csproj
@@ -69,6 +69,7 @@
   <ItemGroup>
     <Compile Include="ChannelNameFactory.cs" />
     <Compile Include="Config.cs" />
+    <Compile Include="FakeUserInfo.cs" />
     <Compile Include="FakeAuthoriser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PusherFactory.cs" />

--- a/PusherClient.Tests/AcceptanceTests/PresenceChannel.cs
+++ b/PusherClient.Tests/AcceptanceTests/PresenceChannel.cs
@@ -94,7 +94,7 @@ namespace PusherClient.Tests.AcceptanceTests
         }
 
         [Test]
-        public void PresenceChannelShouldUseGenericWhenGivenAMemberAsync()
+        public void PresenceChannelShouldAddATypedMemberWhenGivenAMemberAsync()
         {
             // Arrange
             var stubOptions = new PusherOptions

--- a/PusherClient.Tests/UnitTests/PusherTests.cs
+++ b/PusherClient.Tests/UnitTests/PusherTests.cs
@@ -194,5 +194,29 @@ namespace PusherClient.Tests.UnitTests
             Assert.IsNotNull(caughtException);
             StringAssert.Contains("Cannot change channel member type; was previously defined as", caughtException.Message);
         }
+
+        [Test]
+        public void PusherShouldThrowAnExceptionWhenSubscribePresenceIsCalledAfterSubscribe()
+        {
+            // Arrange
+            InvalidOperationException caughtException = null;
+
+            // Act
+            var pusher = new Pusher("FakeAppKey", new PusherOptions { Authorizer = new FakeAuthoriser("test") });
+            AsyncContext.Run(() => pusher.SubscribeAsync("presence-123"));
+
+            try
+            {
+                AsyncContext.Run(() => pusher.SubscribePresenceAsync<int>("presence-123"));
+            }
+            catch (InvalidOperationException ex)
+            {
+                caughtException = ex;
+            }
+
+            // Assert
+            Assert.IsNotNull(caughtException);
+            StringAssert.Contains("This presence channel has already been created without specifying the member info type", caughtException.Message);
+        }
     }
 }

--- a/PusherClient.Tests/UnitTests/PusherTests.cs
+++ b/PusherClient.Tests/UnitTests/PusherTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Nito.AsyncEx;
 using NUnit.Framework;
+using PusherClient.Tests.Utilities;
 
 namespace PusherClient.Tests.UnitTests
 {
@@ -146,6 +147,52 @@ namespace PusherClient.Tests.UnitTests
             // Assert
             Assert.IsNotNull(caughtException);
             StringAssert.Contains("The channel name cannot be null or whitespace", caughtException.Message);
+        }
+
+        [Test]
+        public void PusherShouldThrowAnExceptionWhenSubscribePresenceIsCalledWithANonPresenceChannelAsync()
+        {
+            // Arrange
+            ArgumentException caughtException = null;
+
+            // Act
+            try
+            {
+                var pusher = new Pusher("FakeAppKey");
+                var channel = AsyncContext.Run(() => pusher.SubscribePresenceAsync<string>("private-123"));
+            }
+            catch (ArgumentException ex)
+            {
+                caughtException = ex;
+            }
+
+            // Assert
+            Assert.IsNotNull(caughtException);
+            StringAssert.Contains("The channel name must be refer to a presence channel", caughtException.Message);
+        }
+
+        [Test]
+        public void PusherShouldThrowAnExceptionWhenSubscribePresenceIsCalledWithADifferentTypeAsync()
+        {
+            // Arrange
+            InvalidOperationException caughtException = null;
+
+            // Act
+            var pusher = new Pusher("FakeAppKey", new PusherOptions { Authorizer = new FakeAuthoriser("test") });
+            AsyncContext.Run(() => pusher.SubscribePresenceAsync<string>("presence-123"));
+
+            try
+            {
+                AsyncContext.Run(() => pusher.SubscribePresenceAsync<int>("presence-123"));
+            }
+            catch (InvalidOperationException ex)
+            {
+                caughtException = ex;
+            }
+
+            // Assert
+            Assert.IsNotNull(caughtException);
+            StringAssert.Contains("Cannot change channel member type; was previously defined as", caughtException.Message);
         }
     }
 }

--- a/PusherClient/EventEmitter.cs
+++ b/PusherClient/EventEmitter.cs
@@ -12,6 +12,9 @@ namespace PusherClient
         private readonly Dictionary<string, List<Action<dynamic>>> _eventListeners = new Dictionary<string, List<Action<dynamic>>>();
         private readonly List<Action<string, dynamic>> _generalListeners = new List<Action<string, dynamic>>();
 
+        private readonly Dictionary<string, List<Action<string>>> _rawEventListeners = new Dictionary<string, List<Action<string>>>();
+        private readonly List<Action<string, string>> _rawGeneralListeners = new List<Action<string, string>>();
+
         /// <summary>
         /// Binds to a given event name
         /// </summary>
@@ -31,6 +34,24 @@ namespace PusherClient
         }
 
         /// <summary>
+        /// Binds to a given event name. The listener will receive the raw JSON message.
+        /// </summary>
+        /// <param name="eventName">The Event Name to listen for</param>
+        /// <param name="listener">The action to perform when the event occurs</param>
+        public void Bind(string eventName, Action<string> listener)
+        {
+            if (_rawEventListeners.ContainsKey(eventName))
+            {
+                _rawEventListeners[eventName].Add(listener);
+            }
+            else
+            {
+                var listeners = new List<Action<string>> { listener };
+                _rawEventListeners.Add(eventName, listeners);
+            }
+        }
+
+        /// <summary>
         /// Binds to ALL event
         /// </summary>
         /// <param name="listener">The action to perform when the any event occurs</param>
@@ -40,12 +61,22 @@ namespace PusherClient
         }
 
         /// <summary>
+        /// Binds to ALL event. The listener will receive the raw JSON message.
+        /// </summary>
+        /// <param name="listener">The action to perform when the any event occurs</param>
+        public void BindAll(Action<string, string> listener)
+        {
+            _rawGeneralListeners.Add(listener);
+        }
+
+        /// <summary>
         /// Removes the binding for the given event name
         /// </summary>
         /// <param name="eventName">The name of the event to unbind</param>
         public void Unbind(string eventName)
         {
             _eventListeners.Remove(eventName);
+            _rawEventListeners.Remove(eventName);
         }
 
         /// <summary>
@@ -55,9 +86,22 @@ namespace PusherClient
         /// <param name="listener">The action to remove</param>
         public void Unbind(string eventName, Action<dynamic> listener)
         {
-            if(_eventListeners.ContainsKey(eventName))
+            if (_eventListeners.ContainsKey(eventName))
             {
                 _eventListeners[eventName].Remove(listener);
+            }
+        }
+
+        /// <summary>
+        /// Remove the action for the event name
+        /// </summary>
+        /// <param name="eventName">The name of the event to unbind</param>
+        /// <param name="listener">The action to remove</param>
+        public void Unbind(string eventName, Action<string> listener)
+        {
+            if (_rawEventListeners.ContainsKey(eventName))
+            {
+                _rawEventListeners[eventName].Remove(listener);
             }
         }
 
@@ -68,23 +112,42 @@ namespace PusherClient
         {
             _eventListeners.Clear();
             _generalListeners.Clear();
+
+            _rawEventListeners.Clear();
+            _rawGeneralListeners.Clear();
         }
 
         internal void EmitEvent(string eventName, string data)
         {
-            var obj = JsonConvert.DeserializeObject<dynamic>(data);
-
-            // Emit to general listeners regardless of event type
-            foreach (var action in _generalListeners)
+            foreach (var action in _rawGeneralListeners)
             {
-                action(eventName, obj);
+                action(eventName, data);
             }
 
-            if (_eventListeners.ContainsKey(eventName))
+            if (_rawEventListeners.ContainsKey(eventName))
             {
-                foreach (var action in _eventListeners[eventName])
+                foreach (var action in _rawEventListeners[eventName])
                 {
-                    action(obj);
+                    action(data);
+                }
+            }
+
+            // Don't bother with deserialization if there are no dynamic listeners
+            if (_generalListeners.Count > 0 || _eventListeners.Count > 0)
+            {
+                var obj = JsonConvert.DeserializeObject<dynamic>(data);
+
+                foreach (var action in _generalListeners)
+                {
+                    action(eventName, obj);
+                }
+
+                if (_eventListeners.ContainsKey(eventName))
+                {
+                    foreach (var action in _eventListeners[eventName])
+                    {
+                        action(obj);
+                    }
                 }
             }
         }

--- a/PusherClient/GenericPresenceChannel.cs
+++ b/PusherClient/GenericPresenceChannel.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace PusherClient
+{
+    /// <summary>
+    /// Represents a Pusher Presence Channel that can be subscribed to
+    /// </summary>
+    /// <typeparam name="T">Type used to deserialize channel member info</typeparam>
+    public class GenericPresenceChannel<T> : PrivateChannel
+    {
+        /// <summary>
+        /// Fires when a Member is Added
+        /// </summary>
+        public event MemberAddedEventHandler<T> MemberAdded;
+
+        /// <summary>
+        /// Fires when a Member is Removed
+        /// </summary>
+        public event MemberRemovedEventHandler MemberRemoved;
+
+        internal GenericPresenceChannel(string channelName, ITriggerChannels pusher) : base(channelName, pusher) { }
+
+        /// <summary>
+        /// Gets the Members of the channel
+        /// </summary>
+        public Dictionary<string, T> Members { get; private set; } = new Dictionary<string, T>();
+
+        internal override void SubscriptionSucceeded(string data)
+        {
+            Members = ParseMembersList(data);
+            base.SubscriptionSucceeded(data);
+        }
+
+        internal void AddMember(string data)
+        {
+            var member = ParseMember(data);
+
+            if (!Members.ContainsKey(member.Key))
+                Members.Add(member.Key, member.Value);
+            else
+                Members[member.Key] = member.Value;
+
+            if (MemberAdded != null)
+                MemberAdded(this, member);
+        }
+
+        internal void RemoveMember(string data)
+        {
+            var member = ParseMember(data);
+
+            if (Members.ContainsKey(member.Key))
+            {
+                Members.Remove(member.Key);
+
+                if (MemberRemoved != null)
+                    MemberRemoved(this);
+            }
+        }
+
+        private class SubscriptionData
+        {
+            public Presence presence { get; set; }
+
+            internal class Presence
+            {
+                public List<string> ids { get; set; }
+                public Dictionary<string, T> hash { get; set; }
+                public int count { get; set; }
+            }
+        }
+
+        private Dictionary<string, T> ParseMembersList(string data)
+        {
+            Dictionary<string, T> members = new Dictionary<string, T>();
+
+            var dataAsObj = JsonConvert.DeserializeObject<SubscriptionData>(data);
+
+            for (int i = 0; i < (int)dataAsObj.presence.count; i++)
+            {
+                var id = dataAsObj.presence.ids[i];
+                var val = dataAsObj.presence.hash[id];
+                members.Add(id, val);
+            }
+
+            return members;
+        }
+
+
+        private class MemberData
+        {
+            public string user_id { get; set; }
+            public T user_info { get; set; }
+        }
+
+        private KeyValuePair<string, T> ParseMember(string data)
+        {
+            var dataAsObj = JsonConvert.DeserializeObject<MemberData>(data);
+
+            var id = dataAsObj.user_id;
+            var val = dataAsObj.user_info;
+
+            return new KeyValuePair<string, T>(id, val);
+        }
+    }
+}

--- a/PusherClient/MemberAddedEventHandler.cs
+++ b/PusherClient/MemberAddedEventHandler.cs
@@ -7,5 +7,5 @@ namespace PusherClient
     /// </summary>
     /// <param name="sender">The Channel that had the member added</param>
     /// <param name="member">The added member information</param>
-    public delegate void MemberAddedEventHandler(object sender, KeyValuePair<string, dynamic> member);
+    public delegate void MemberAddedEventHandler<T>(object sender, KeyValuePair<string, T> member);
 }

--- a/PusherClient/PresenceChannel.cs
+++ b/PusherClient/PresenceChannel.cs
@@ -4,83 +4,10 @@ using Newtonsoft.Json;
 namespace PusherClient
 {
     /// <summary>
-    /// Represents a Pusher Presence Channel that can be subscribed to
+    /// This class exists for backwards compatibility with code that isn't using GenericPresenceChannel.
     /// </summary>
-    public class PresenceChannel : PrivateChannel
+    public class PresenceChannel : GenericPresenceChannel<dynamic>
     {
-        /// <summary>
-        /// Fires when a Member is Added
-        /// </summary>
-        public event MemberAddedEventHandler MemberAdded;
-
-        /// <summary>
-        /// Fires when a Member is Removed
-        /// </summary>
-        public event MemberRemovedEventHandler MemberRemoved;
-
         internal PresenceChannel(string channelName, ITriggerChannels pusher) : base(channelName, pusher) { }
-
-        /// <summary>
-        /// Gets the Members of the channel
-        /// </summary>
-        public Dictionary<string, dynamic> Members { get; private set; } = new Dictionary<string, dynamic>();
-
-        internal override void SubscriptionSucceeded(string data)
-        {
-            Members = ParseMembersList(data);
-            base.SubscriptionSucceeded(data);
-        }
-
-        internal void AddMember(string data)
-        {
-            var member = ParseMember(data);
-
-            if (!Members.ContainsKey(member.Key))
-                Members.Add(member.Key, member.Value);
-            else
-                Members[member.Key] = member.Value;
-
-            if (MemberAdded != null)
-                MemberAdded(this, member);
-        }
-
-        internal void RemoveMember(string data)
-        {
-            var member = ParseMember(data);
-
-            if (Members.ContainsKey(member.Key))
-            {
-                Members.Remove(member.Key);
-
-                if (MemberRemoved != null)
-                    MemberRemoved(this);
-            }
-        }
-
-        private Dictionary<string, dynamic> ParseMembersList(string data)
-        {
-            Dictionary<string, dynamic> members = new Dictionary<string, dynamic>();
-
-            var dataAsObj = JsonConvert.DeserializeObject<dynamic>(data);
-
-            for (int i = 0; i < (int)dataAsObj.presence.count; i++)
-            {
-                var id = (string)dataAsObj.presence.ids[i];
-                var val = (dynamic)dataAsObj.presence.hash[id];
-                members.Add(id, val);
-            }
-
-            return members;
-        }
-
-        private KeyValuePair<string, dynamic> ParseMember(string data)
-        {
-            var dataAsObj = JsonConvert.DeserializeObject<dynamic>(data);
-
-            var id = (string)dataAsObj.user_id;
-            var val = (dynamic)dataAsObj.user_info;
-
-            return new KeyValuePair<string, dynamic>(id, val);
-        }
     }
 }


### PR DESCRIPTION
Looking for early feedback. I haven't plugged this in to fully test end-to-end yet. 

The `PresenceChannel` change wasn't as easy as I had thought. I didn't want to store the member info as raw JSON, because it would force consumers to either repeatedly deserialize it or maintain their own cache, which isn't very friendly.

I ended up refactoring it into a generic, so the consumer can provide the model that they want to use for the member info. However, this doesn't play very well with the way channels are created, and having two different ways to subscribe to a presence channel is not ideal. It definitely introduces some ugliness. Let me know if you have any better ideas.