### PR TITLE
Removing extra double quotes from serialized event data

### DIFF
--- a/PusherClient.Tests/AcceptanceTests/EventEmitter.cs
+++ b/PusherClient.Tests/AcceptanceTests/EventEmitter.cs
@@ -64,7 +64,7 @@ namespace PusherClient.Tests.AcceptanceTests
             // Assert
             Assert.IsNotNull(emittedEvent);
             StringAssert.AreEqualIgnoringCase("channel event", emittedEvent.EventName);
-            StringAssert.AreEqualIgnoringCase("\"{\\\"stuff\\\":1234}\"", emittedEvent.Data);
+            StringAssert.AreEqualIgnoringCase("{\"stuff\":1234}", emittedEvent.Data);
         }
 
         [Test]
@@ -354,7 +354,7 @@ namespace PusherClient.Tests.AcceptanceTests
             var eventData = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonMessage);
 
             if (jObject["data"] != null)
-                eventData["data"] = jObject["data"].ToString(Formatting.None); // undo any kind of deserialisation
+                eventData["data"] = jObject["data"].ToString(); // undo any kind of deserialisation
 
             return new PusherEvent(eventData, jsonMessage);
         }

--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -136,7 +136,7 @@ namespace PusherClient
             var eventData = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonMessage);
 
             if (jObject["data"] != null)
-                eventData["data"] = jObject["data"].ToString(Formatting.None); // undo any kind of deserialisation of the data property
+                eventData["data"] = jObject["data"].ToString(); // undo any kind of deserialisation of the data property
 
             var receivedEvent = new PusherEvent(eventData, jsonMessage);
 


### PR DESCRIPTION
This fixes a bug where the `Data` property of the `PusherEvent` is being wrapped in an extra pair of double quotes. i.e. the property would contain `"{"foo":"bar"}"` instead of the expected `{"foo":"bar"}`

We've already coerced `jObject["data"]` into an unformatted string earlier, so it shouldn't be necessary to specify formatting here.