### PR TITLE
Fix #78, #85 JsonReaderException in HttpAuthorizer

### DIFF
--- a/PusherClient.Tests/App.config
+++ b/PusherClient.Tests/App.config
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="PUSHER_APP_ID" value=""/>
-    <add key="PUSHER_APP_KEY" value=""/>
-    <add key="PUSHER_APP_SECRET" value=""/>
+    <add key="PUSHER_APP_ID" value="" />
+    <add key="PUSHER_APP_KEY" value="" />
+    <add key="PUSHER_APP_SECRET" value="" />
   </appSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/PusherClient.Tests/PusherClient.Tests.csproj
+++ b/PusherClient.Tests/PusherClient.Tests.csproj
@@ -47,6 +47,9 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
+    <Reference Include="Mock4Net.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mock4Net.Core.1.0.0-v20150608-4f463ad\lib\net45\Mock4Net.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -86,6 +89,7 @@
     <Compile Include="AcceptanceTests\PresenceChannel.cs" />
     <Compile Include="AcceptanceTests\Subscription.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitTests\HttpAuthorizer.cs" />
     <Compile Include="UnitTests\PusherEvent.cs" />
     <Compile Include="UnitTests\PusherTests.cs" />
   </ItemGroup>

--- a/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
+++ b/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Mock4Net.Core;
+
+namespace PusherClient.Tests.UnitTests
+{
+    [TestFixture]
+    public class HttpAuthorizer
+    {
+        [Test]
+        public void HttpAuthorizerShouldReturnStringToken()
+        {
+
+            int hostPort = 3000;
+            string hostUrl = "http://localhost:" + (hostPort).ToString();
+            string FakeTokenAuth = "{auth: 'b928ab800c5c554a47ad:f41b9934520700d8474928d03ea7d808cab0cc7fcec082676f6b73ca0d9ab2b'}";
+
+            var server = FluentMockServer.Start(hostPort);
+            server
+                .Given(
+                    Requests.WithUrl("/authz").UsingPost()
+                )
+                .RespondWith(
+                    Responses
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type","application/json")
+                        .WithBody(FakeTokenAuth)
+                );
+
+            var testHttpAuthorizer = new PusherClient.HttpAuthorizer(hostUrl + "/authz");
+            var AuthToken = testHttpAuthorizer.Authorize("private-test", "fsfsdfsgsfs");
+
+            Assert.AreNotEqual("System.Net.Http.StreamContent", AuthToken);
+            Assert.AreEqual(FakeTokenAuth, AuthToken);
+        }
+
+    }
+}

--- a/PusherClient.Tests/packages.config
+++ b/PusherClient.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Mock4Net.Core" version="1.0.0-v20150608-4f463ad" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="Nito.AsyncEx" version="4.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net45" requireReinstallation="true" />

--- a/PusherClient/HttpAuthorizer.cs
+++ b/PusherClient/HttpAuthorizer.cs
@@ -41,7 +41,7 @@ namespace PusherClient
                 HttpContent content = new FormUrlEncodedContent(data);
 
                 var response = httpClient.PostAsync(_authEndpoint, content).Result;
-                authToken = response.Content.ToString();
+                authToken = response.Content.ReadAsStringAsync().Result;
             }
 
             return authToken;


### PR DESCRIPTION
This PR aims to fix #78 and fix #85,
both highlighting a _JsonReaderException_ happening in `HttpAuthorizer.Authorize()`: 
```
JsonReaderException: Unexpected character encountered while parsing value: S. Path '', line 0, position 0
```
 where `response.Content.ToString()`
returns a `System.Net.Http.StreamContent` instead of the expected `String`.

This is fixed by utilizing `ReadAsStringAsync()` to _serialize the HTTP content to a string as an asynchronous operation_ followed by a `.Result` which waits for the operation to complete and fetches the `String` with the HTTP content from the returned task object.