### PR TITLE
Reset _backOffMillis when reconnected correctly

### DIFF
--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -191,6 +191,7 @@ namespace PusherClient
             Pusher.Trace.TraceEvent(TraceEventType.Information, 0, "Websocket opened OK.");
             _connectionTaskComplete.SetResult(ConnectionState.Connected);
             _connectionTaskCompleted = true;
+            _backOffMillis = 0;
         }
 
         private void websocket_Closed(object sender, EventArgs e)


### PR DESCRIPTION
This fixes a bug in the reconnection logic where the increased `_backOffMillis` delay was
not reset after a successful reconnection.

This lead to the client always waiting a non-zero delay before attempting a reconnection upon previous reconnections.

Based on a suggestion from @rh78 in #90, thank you.