### PR TITLE
feature:(auth) support authorisation header with HttpAuthorizer

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -72,6 +72,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.NameResolution, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.NameResolution.4.3.0\lib\net46\System.Net.NameResolution.dll</HintPath>
       <Private>True</Private>

--- a/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
+++ b/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
@@ -30,6 +30,8 @@ namespace PusherClient.Tests.UnitTests
             var testHttpAuthorizer = new PusherClient.HttpAuthorizer(hostUrl + "/authz");
             var AuthToken = testHttpAuthorizer.Authorize("private-test", "fsfsdfsgsfs");
 
+            server.Stop();
+
             Assert.AreNotEqual("System.Net.Http.StreamContent", AuthToken);
             Assert.AreEqual(FakeTokenAuth, AuthToken);
         }
@@ -59,6 +61,8 @@ namespace PusherClient.Tests.UnitTests
 
             var testHttpAuthorizer = new PusherClient.HttpAuthorizer(hostUrl + "/authz", FakeBearerToken);
             var AuthToken = testHttpAuthorizer.Authorize("private-test", "fsfsdfsgsfs");
+
+            server.Stop();
 
             Assert.AreNotEqual("System.Net.Http.StreamContent", AuthToken);
             Assert.AreEqual(FakeTokenAuth, AuthToken);

--- a/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
+++ b/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
@@ -34,5 +34,34 @@ namespace PusherClient.Tests.UnitTests
             Assert.AreEqual(FakeTokenAuth, AuthToken);
         }
 
+        [Test]
+        public void HttpAuthorizerWithBearerTokenShouldReturnStringToken()
+        {
+
+            int hostPort = 3000;
+            string hostUrl = "http://localhost:" + (hostPort).ToString();
+            string FakeBearerToken = "noo6xaeN3cohYoozai4ar8doang7ai1elaeTh1di";
+            string FakeTokenAuth = "{auth: 'fohgheoghowi2Zaehai0aixe8as9laiQuahJeez78d03ea7d808cab0cc7fcec082676f6b73ca0d9ab2b'}";
+
+            var server = FluentMockServer.Start(hostPort);
+            server
+                .Given(
+                    Requests
+                        .WithUrl("/authz").UsingPost()
+                        .WithHeader("Authorization", $"Bearer {FakeBearerToken}")
+                )
+                .RespondWith(
+                    Responses
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type","application/json")
+                        .WithBody(FakeTokenAuth)
+                );
+
+            var testHttpAuthorizer = new PusherClient.HttpAuthorizer(hostUrl + "/authz", FakeBearerToken);
+            var AuthToken = testHttpAuthorizer.Authorize("private-test", "fsfsdfsgsfs");
+
+            Assert.AreNotEqual("System.Net.Http.StreamContent", AuthToken);
+            Assert.AreEqual(FakeTokenAuth, AuthToken);
+        }
     }
 }

--- a/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
+++ b/PusherClient.Tests/UnitTests/HttpAuthorizer.cs
@@ -40,7 +40,7 @@ namespace PusherClient.Tests.UnitTests
         public void HttpAuthorizerWithBearerTokenShouldReturnStringToken()
         {
 
-            int hostPort = 3000;
+            int hostPort = 3001;
             string hostUrl = "http://localhost:" + (hostPort).ToString();
             string FakeBearerToken = "noo6xaeN3cohYoozai4ar8doang7ai1elaeTh1di";
             string FakeTokenAuth = "{auth: 'fohgheoghowi2Zaehai0aixe8as9laiQuahJeez78d03ea7d808cab0cc7fcec082676f6b73ca0d9ab2b'}";

--- a/PusherClient/HttpAuthorizer.cs
+++ b/PusherClient/HttpAuthorizer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace PusherClient
 {
@@ -10,17 +11,32 @@ namespace PusherClient
     public class HttpAuthorizer: IAuthorizer
     {
         private readonly Uri _authEndpoint;
-        private string _bearerToken;
+        private AuthenticationHeaderValue _authenticationHeader;
 
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="authEndpoint">The End point to contact</param>
         /// <param name="bearerToken">Optional bearer token</param>
-        public HttpAuthorizer(string authEndpoint, string bearerToken = null)
+        public HttpAuthorizer(string authEndpoint, string bearerToken) :
+            this(
+                authEndpoint,
+                !string.IsNullOrEmpty(bearerToken)
+                    ? new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearerToken)
+                    : null
+            )
+        {
+        }
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="authEndpoint">The End point to contact</param>
+        /// <param name="authenticationHeader">(optional) arbitrary authentication header</param>
+        public HttpAuthorizer(string authEndpoint, AuthenticationHeaderValue authenticationHeader = null)
         {
             _authEndpoint = new Uri(authEndpoint);
-            _bearerToken = bearerToken;
+            _authenticationHeader = authenticationHeader;
         }
 
         /// <summary>
@@ -43,9 +59,9 @@ namespace PusherClient
 
                 HttpContent content = new FormUrlEncodedContent(data);
 
-                if (!string.IsNullOrEmpty(_bearerToken))
+                if (_authenticationHeader != null)
                 {
-                    httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _bearerToken);
+                    httpClient.DefaultRequestHeaders.Authorization = _authenticationHeader;
                 }
 
                 var response = httpClient.PostAsync(_authEndpoint, content).Result;

--- a/PusherClient/HttpAuthorizer.cs
+++ b/PusherClient/HttpAuthorizer.cs
@@ -10,14 +10,17 @@ namespace PusherClient
     public class HttpAuthorizer: IAuthorizer
     {
         private readonly Uri _authEndpoint;
+        private string _bearerToken;
 
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="authEndpoint">The End point to contact</param>
-        public HttpAuthorizer(string authEndpoint)
+        /// <param name="bearerToken">Optional bearer token</param>
+        public HttpAuthorizer(string authEndpoint, string bearerToken = null)
         {
             _authEndpoint = new Uri(authEndpoint);
+            _bearerToken = bearerToken;
         }
 
         /// <summary>
@@ -39,6 +42,11 @@ namespace PusherClient
                 };
 
                 HttpContent content = new FormUrlEncodedContent(data);
+
+                if (!string.IsNullOrEmpty(_bearerToken))
+                {
+                    httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _bearerToken);
+                }
 
                 var response = httpClient.PostAsync(_authEndpoint, content).Result;
                 authToken = response.Content.ReadAsStringAsync().Result;


### PR DESCRIPTION
This is an improved version, based on suggestions from [PR 90](https://github.com/pusher/pusher-websocket-dotnet/pull/90).

Using the HTTP authoriser to check access for private channels requires user access checks. So the HTTP endpoint needs to know which user is authorised.

HTTP provides "Authorization" header for the task to link an HTTP request to a user. Unfortunately the HTTP authoriser has not supported using such an HTTP header - until now.

The new constructor parameter allows to set an optional authorisation header to the HTTP request.


