### PR TITLE
Fixed DisposeWebsocket

### DIFF
--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -458,12 +458,16 @@ namespace PusherClient
 
         private void DisposeWebsocket()
         {
+            if (_websocket != null)
+            {
+                _websocket.MessageReceived -= WebsocketMessageReceived;
+                _websocket.Closed -= WebsocketAutoReconnect;
+                _websocket.Error -= WebsocketError;
+                _websocket.Dispose();
+                _websocket = null;
+            }
+
             _currentError = null;
-            _websocket.MessageReceived -= WebsocketMessageReceived;
-            _websocket.Closed -= WebsocketAutoReconnect;
-            _websocket.Error -= WebsocketError;
-            _websocket.Dispose();
-            _websocket = null;
             ChangeState(ConnectionState.Disconnected);
         }
 


### PR DESCRIPTION
## Description

This is a common bug that happens when you use Pusher with WebSockets. What happens is that when your connection drops, the WebSocket object gets disposed of and set to null. But then when the pusher tries to reconnect, it doesn't check if the WebSocket is null or not. It just tries to dispose of it again, and that causes a null reference error.

## CHANGELOG

* Fixed https://github.com/pusher/pusher-websocket-dotnet/issues/116
