### PR TITLE
Fix crash on Pusher.DisconnectAsync() when used with Unity 2021 Game Engine on game consoles

### DIFF
--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -88,6 +88,8 @@ namespace PusherClient
 
         public async Task DisconnectAsync()
         {
+            try
+            {
             if (_websocket != null)
             {
                 if (State != ConnectionState.Disconnected)
@@ -101,10 +103,28 @@ namespace PusherClient
 
                     await Task.Run(() =>
                     {
+                            try
+                            {
                         _websocket.Close();
-                    }).ConfigureAwait(false);
+                            }
+                            catch(Exception e)
+                            {
+                                if(_pusher.PusherOptions.TraceLogger != null)
+                                {
+                                    _pusher.PusherOptions.TraceLogger.TraceError($"Websocket close exception: {e.Message}");
+                                }
+                            }
 
+                        });
                     DisposeWebsocket();
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                if(_pusher.PusherOptions.TraceLogger != null)
+                {
+                    _pusher.PusherOptions.TraceLogger.TraceError($"DisconnectAsync exception: {e.Message}");
                 }
             }
         }


### PR DESCRIPTION

## Description

While developing for game consoles using Unity 2021.3.33f1 and code compiled with il2cpp  we encountered a strange crash.
This crash could be reproduced also on development builds (The normal behavior is for exception to be logged on development build, not crashing).

The crash resulted no useful crash dump and no useful logs.

We narrowed it down to the `Pusher.DisconnectAsync()`.

These changes fixed the issue.
## CHANGELOG

* [CHANGED] `Connection.cs` Added try-catch to `_websocket.Close()`.

* [CHANGED] `Pusher.cs`
    * Removed all `Task.ConfigureAwait(false)` ( Unity is really sensitive about what's getting called from what thread) 
    * Removed `throw` when catching exceptions (These exception when thrown on a game console would result an instant crash)