### PR TITLE
Added EnabledSslProtocols option in the PusherOptions

### DIFF
--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -50,11 +50,7 @@ namespace PusherClient
 
                 ChangeState(ConnectionState.Connecting);
 
-                _websocket = new WebSocket(_url)
-                {
-                    EnableAutoSendPing = true,
-                    AutoSendPingInterval = 1
-                };
+                CreateNewWebSocket();
 
                 await Task.Run(() =>
                 {
@@ -467,14 +463,29 @@ namespace PusherClient
             ChangeState(ConnectionState.Disconnected);
         }
 
-        private void RecreateWebSocket()
+        private void CreateNewWebSocket()
         {
-            DisposeWebsocket();
-            _websocket = new WebSocket(_url)
+            _websocket = new WebSocket(_url,
+                                        "",                     //string subProtocol = "",
+                                        null,                   //List<KeyValuePair<string, string>> cookies = null,
+                                        null,                   //List<KeyValuePair<string, string>> customHeaderItems = null,
+                                        "",                     //string userAgent = "",
+                                        "",                     //string origin = "",
+                                        WebSocketVersion.None,  // WebSocketVersion version = WebSocketVersion.None,
+                                        null,                   // EndPoint httpConnectProxy = null,
+                                        _pusher.PusherOptions.EnabledSslProtocols,
+                                        0)                      // int receiveBufferSize = 0)
             {
                 EnableAutoSendPing = true,
                 AutoSendPingInterval = 1
             };
+        }
+
+
+        private void RecreateWebSocket()
+        {
+            DisposeWebsocket();
+            CreateNewWebSocket();
         }
 
         private void ParseError(JToken jToken)

--- a/PusherClient/PusherOptions.cs
+++ b/PusherClient/PusherOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Authentication;
 
 namespace PusherClient
 {
@@ -103,6 +104,12 @@ namespace PusherClient
         /// Gets or sets the timeout period to wait for an asynchrounous operation to complete. The default value is 30 seconds.
         /// </summary>
         public TimeSpan ClientTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+
+        /// <summary>
+        /// Gets or sets the ssl security protocol to communicate. The default value is SslProtocols.None.
+        /// </summary>
+        public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.None;
 
         /// <summary>
         /// Gets or sets the <see cref="ITraceLogger"/> to use for tracing debug messages.


### PR DESCRIPTION
Enable to let the calling client choose which SSL protocol to use, for example SslProtocols.Tls12 instead of the default SslProtocols.None.

In connection.cs we use this option in the Websocket constructor.

