### PR TITLE
Fix unity tls support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     steps:
     - uses: actions/checkout@v2

--- a/AuthHost/App.config
+++ b/AuthHost/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Port" value="8888" />
+    <add key="Port" value="9000" />
   </appSettings>
 </configuration>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.1
+* [Changed] Force TLS 1.2
+
 ## 2.3.0-beta
 * [Added] Introduce user features
 
@@ -21,7 +24,7 @@
 * [FIXED] Filter on event name in event emitter.
 
 ## 2.0.0
-* [FIXED] Infinite loop when failing to connect for the first time. 
+* [FIXED] Infinite loop when failing to connect for the first time.
 * [FIXED] Bug: GenericPresenceChannel<T>'s AddMember and RemoveMember events were not being emitted.
 * [FIXED] Change MemberRemovedEventHandler to MemberRemovedEventHandler<T>.
 * [FIXED] Introduce new ChannelUnauthorizedException class.

--- a/PusherClient/Pusher.cs
+++ b/PusherClient/Pusher.cs
@@ -73,6 +73,26 @@ namespace PusherClient
         private SemaphoreSlim _connectLock = new SemaphoreSlim(1);
         private SemaphoreSlim _disconnectLock = new SemaphoreSlim(1);
 
+        static Pusher()
+        {
+            #if NETSTANDARD2_0 || NET472 || NETSTANDARD1_3
+            try
+            {
+                System.Net.ServicePointManager.SecurityProtocol |=
+                    System.Net.SecurityProtocolType.Tls12;
+            }
+            catch
+            {
+                try
+                {
+                    System.Net.ServicePointManager.SecurityProtocol =
+                        (System.Net.SecurityProtocolType)3072; // TLS 1.2
+                }
+                catch { }
+            }
+            #endif
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Pusher" /> class.
         /// </summary>

--- a/PusherClient/Pusher.cs
+++ b/PusherClient/Pusher.cs
@@ -75,7 +75,7 @@ namespace PusherClient
 
         static Pusher()
         {
-            #if NETSTANDARD2_0 || NET472 || NETSTANDARD1_3
+            #if NET45 || NET472 || NETSTANDARD2_0
             try
             {
                 System.Net.ServicePointManager.SecurityProtocol |=

--- a/Root.Build.props
+++ b/Root.Build.props
@@ -12,7 +12,7 @@
     <PackageDescription>The .NET library for interacting with the Pusher WebSocket API. Register at http://pusher.com</PackageDescription>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon-128.png</PackageIcon>
-    <Version>2.3.0-beta</Version>
+    <Version>2.3.1</Version>
     <AssemblyVersion>2.3.0.0</AssemblyVersion>
     <FileVersion>2.3.0.0</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Description

A possible fix for https://github.com/pusher/pusher-websocket-unity/issues/62

## CHANGELOG

* [CHANGED] Force TLS 1.2 by default.
